### PR TITLE
fix: corrigindo timezone da aplicação

### DIFF
--- a/config/app.php
+++ b/config/app.php
@@ -69,7 +69,7 @@ return [
     |
     */
 
-    'timezone' => 'UTC',
+    'timezone' => 'America/Sao_Paulo',
 
     /*
     |--------------------------------------------------------------------------
@@ -181,7 +181,7 @@ return [
         Illuminate\Translation\TranslationServiceProvider::class,
         Illuminate\Validation\ValidationServiceProvider::class,
         Illuminate\View\ViewServiceProvider::class,
-       
+
 
         /*
          * Package Service Providers...
@@ -211,7 +211,7 @@ return [
 
     'aliases' => Facade::defaultAliases()->merge([
         // 'ExampleClass' => App\Example\ExampleClass::class,
-        
+
     ])->toArray(),
 
 ];


### PR DESCRIPTION
O timezone da aplicação estava definido como UTC, o que gerava registros de created_at e updated_at com um fuso horário diferente. Troquei o timezone UTC por America/Sao_Paulo.